### PR TITLE
update clojurescript dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,8 @@
   :url "https://github.com/jkk/verily"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-1843"]]
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [org.clojure/clojurescript "0.0-2311"]]
   :source-paths ["src/cljx"]
   :test-paths ["target/test-classes"]
   :cljx {:builds [{:source-paths ["src/cljx"]


### PR DESCRIPTION
Having older versions of clojurescript in the dependency tree seems to cause issues with using Light Table.

```
Error loading lighttable.nrepl.handler: java.io.FileNotFoundException: Could not locate cljs/env__init.class or cljs/env.clj on classpath: , compiling:(lighttable/nrepl/sonar.clj:1:1)
```
